### PR TITLE
Use recommended pins/slot

### DIFF
--- a/examples/play-mono-wav-from-sdcard-uasyncio.py
+++ b/examples/play-mono-wav-from-sdcard-uasyncio.py
@@ -53,10 +53,12 @@ async def play_wav():
         samplerate=SAMPLE_RATE_IN_HZ,
         dmacount=10, dmalen=512)
     
-    # configure SD card
+    # configure SD card:
+    # See [docs](https://docs.micropython.org/en/latest/library/machine.SDCard.html#esp32) for
+    # recommended pins depending on the chosen slot.
     #   slot=2 configures SD card to use the SPI3 controller (VSPI), DMA channel = 2
     #   slot=3 configures SD card to use the SPI2 controller (HSPI), DMA channel = 1
-    sd = SDCard(slot=3, sck=Pin(18), mosi=Pin(23), miso=Pin(19), cs=Pin(4))
+    sd = SDCard(slot=2, sck=Pin(18), mosi=Pin(23), miso=Pin(19), cs=Pin(5))
     uos.mount(sd, "/sd")
     wav_file = '/sd/{}'.format(WAV_FILE)
     wav = open(wav_file,'rb')


### PR DESCRIPTION
The example works as-is, however it kinda mixes the recommended HSPI CS pin with the VSPI SCK/MISO/MOSI pins and channel.
This simply edits the SDCard init to follow the recommended setup.

Not sure it has a lot of value but as I was setting up my own SD Card reader I had issues and found it confusing that the example code was not following the docs.